### PR TITLE
BugFix: Preserve ports in URI

### DIFF
--- a/src/Tableau.Migration.App.GUI/Constants.cs
+++ b/src/Tableau.Migration.App.GUI/Constants.cs
@@ -30,7 +30,7 @@ public static class Constants
     /// <summary>
     /// The App version number.
     /// </summary>
-    public const string Version = "v1.0.2";
+    public const string Version = "v1.0.3";
 
     /// <summary>
     /// The App name with version.

--- a/src/Tableau.Migration.App.GUI/ViewModels/UriDetailsViewModel.cs
+++ b/src/Tableau.Migration.App.GUI/ViewModels/UriDetailsViewModel.cs
@@ -99,7 +99,7 @@ public partial class UriDetailsViewModel
     {
         if (Uri.TryCreate(uri, UriKind.Absolute, out var parsedUri))
         {
-            return $"{parsedUri.Scheme}://{parsedUri.Host}/";
+            return $"{parsedUri.Scheme}://{parsedUri.Authority}/";
         }
 
         return string.Empty;
@@ -116,8 +116,8 @@ public partial class UriDetailsViewModel
             for (int i = 0; i < fragmentSegments.Length; i++)
             {
                 if (fragmentSegments[i].Equals(
-                        "site",
-                        StringComparison.OrdinalIgnoreCase)
+                    "site",
+                    StringComparison.OrdinalIgnoreCase)
                     && i + 1 < fragmentSegments.Length)
                 {
                     return fragmentSegments[i + 1];

--- a/tests/Tableau.Migration.App.GUI.Tests/ViewModels/UriDetailsViewModel.cs
+++ b/tests/Tableau.Migration.App.GUI.Tests/ViewModels/UriDetailsViewModel.cs
@@ -37,6 +37,18 @@ public class UriDetailsViewModelTests
     }
 
     [AvaloniaFact]
+    public void UriFull_SetValidUri_PreservesPort()
+    {
+        var viewModel = new UriDetailsViewModel();
+        var testUri = "https://example.com:1234/#/site/mysite";
+
+        viewModel.UriFull = testUri;
+
+        Assert.Equal("https://example.com:1234/", viewModel.UriBase);
+        Assert.Equal("mysite", viewModel.SiteContent);
+    }
+
+    [AvaloniaFact]
     public void UriFull_SetInvalidUri_AddsUriFormatError()
     {
         var viewModel = new UriDetailsViewModel();


### PR DESCRIPTION
Bugfix to preserve ports in the URI field. 

Before the fix:
![Before](https://github.com/user-attachments/assets/f75cf665-3fdc-4fed-bd18-d4dd7a112fa4)

After the fix:
![After](https://github.com/user-attachments/assets/d048a5ad-ee03-4dca-a819-090a139f8555)

Will need to perform some verification with an existing server prior to merging. Due to some issues, I cannot test this scenario with our Tableau Server setup. 