### PR TITLE
Updating SDK to use latest minor version with 5.*

### DIFF
--- a/src/Tableau.Migration.App.Core/Tableau.Migration.App.Core.csproj
+++ b/src/Tableau.Migration.App.Core/Tableau.Migration.App.Core.csproj
@@ -31,15 +31,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.*" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
-    <PackageReference Include="Tableau.Migration" Version="5.1.*" />
+    <PackageReference Include="Tableau.Migration" Version="5.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tableau.Migration.App.GUI/Constants.cs
+++ b/src/Tableau.Migration.App.GUI/Constants.cs
@@ -30,7 +30,7 @@ public static class Constants
     /// <summary>
     /// The App version number.
     /// </summary>
-    public const string Version = "v1.0.4";
+    public const string Version = "v1.0.5";
 
     /// <summary>
     /// The App name with version.


### PR DESCRIPTION
Updating SDK version to use 5.* instead of having to specify minor version so that changes in the Tableau server will have a smaller chance of breaking the Migration app with any potentially breaking API changes.