### PR TITLE
Update Migration SDK Version to 6.0.0 and make other package updates

### DIFF
--- a/src/Tableau.Migration.App.Core/Tableau.Migration.App.Core.csproj
+++ b/src/Tableau.Migration.App.Core/Tableau.Migration.App.Core.csproj
@@ -27,19 +27,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="coverlet.msbuild" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
-    <PackageReference Include="Tableau.Migration" Version="5.1.*" />
+    <PackageReference Include="Tableau.Migration" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tableau.Migration.App.GUI/Tableau.Migration.App.GUI.csproj
+++ b/src/Tableau.Migration.App.GUI/Tableau.Migration.App.GUI.csproj
@@ -24,24 +24,24 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.1.0" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.1.0" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.0" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.0" />
+    <PackageReference Include="Avalonia" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.12" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.0" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
-    <PackageReference Include="CsvHelper" Version="33.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.12" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="CsvHelper" Version="33.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Reactive" Version="6.0.1" />
+    <PackageReference Include="System.Reactive" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Tableau.Migration.App.Core.Tests/Entities/AppSettings.cs
+++ b/tests/Tableau.Migration.App.Core.Tests/Entities/AppSettings.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System.Threading;
+using System.Threading.Tasks;
 using Tableau.Migration;
 using Tableau.Migration.App.Core.Entities;
 using Tableau.Migration.App.Core.Hooks.Mappings;
@@ -33,7 +34,7 @@ using Xunit;
 public class AppSettingsTest
 {
     [Fact]
-    public async void AppSettings_UseSimulator_True()
+    public async Task AppSettings_UseSimulator_True()
     {
         var services = new ServiceCollection();
         var appSettings = new AppSettings();
@@ -61,7 +62,7 @@ public class AppSettingsTest
     }
 
     [Fact(Skip = "Skipped since SDK Retries will make this test take several minutes to complete.")]
-    public async void AppSettings_UseSimulator_False()
+    public async Task AppSettings_UseSimulator_False()
     {
         var services = new ServiceCollection();
         services.AddLogging(configure => configure.AddConsole());

--- a/tests/Tableau.Migration.App.Core.Tests/Service/TableauMigrationService.cs
+++ b/tests/Tableau.Migration.App.Core.Tests/Service/TableauMigrationService.cs
@@ -68,18 +68,20 @@ public class TableauMigrationServiceTests
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
-                It.IsAny<bool>())).Returns(
-                (Uri url, string site, string tokenName, string token, bool useSim)
-                => planBuilder.FromSourceTableauServer(url, site, tokenName, token, true));
+                It.IsAny<bool>(),
+                It.IsAny<string>())).Returns(
+                (Uri url, string site, string tokenName, string token, bool useSim, string? contentUrl)
+                => planBuilder.FromSourceTableauServer(url, site, tokenName, token, true, contentUrl ?? string.Empty));
         this.mockPlanBuilder.Setup(
             pb => pb.ToDestinationTableauCloud(
                 It.IsAny<Uri>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
-                It.IsAny<bool>())).Returns(
-                (Uri url, string site, string tokenName, string token, bool useSim)
-                => planBuilder.ToDestinationTableauCloud(url, site, tokenName, token, true));
+                It.IsAny<bool>(),
+                It.IsAny<string>())).Returns(
+                (Uri url, string site, string tokenName, string token, bool useSim, string? contentUrl)
+                => planBuilder.ToDestinationTableauCloud(url, site, tokenName, token, true, contentUrl ?? string.Empty));
         this.mockMigrator = new Mock<IMigrator>();
         this.mockLogger = new Mock<ILogger<TableauMigrationService>>();
         this.mockProgressUpdater = new Mock<IProgressUpdater>();

--- a/tests/Tableau.Migration.App.Core.Tests/Tableau.Migration.App.Core.Tests.csproj
+++ b/tests/Tableau.Migration.App.Core.Tests/Tableau.Migration.App.Core.Tests.csproj
@@ -9,20 +9,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="coverlet.msbuild" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Tableau.Migration.App.GUI.Tests/Tableau.Migration.App.GUI.Tests.csproj
+++ b/tests/Tableau.Migration.App.GUI.Tests/Tableau.Migration.App.GUI.Tests.csproj
@@ -9,20 +9,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Headless.XUnit" Version="11.2.0" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.0" />
-    <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+    <PackageReference Include="Avalonia.Headless.XUnit" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
+    <PackageReference Include="coverlet.msbuild" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
- Updates the Migration SDK version to `6.0.0` and also updates other 3PP
- Makes compatibility code fixes per the above