### PR TITLE
Update Migration SDK to 6.1.0

### DIFF
--- a/src/Tableau.Migration.App.Core/Tableau.Migration.App.Core.csproj
+++ b/src/Tableau.Migration.App.Core/Tableau.Migration.App.Core.csproj
@@ -39,7 +39,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
-    <PackageReference Include="Tableau.Migration" Version="6.0.0" />
+    <PackageReference Include="Tableau.Migration" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tableau.Migration.App.GUI/Constants.cs
+++ b/src/Tableau.Migration.App.GUI/Constants.cs
@@ -30,7 +30,7 @@ public static class Constants
     /// <summary>
     /// The App version number.
     /// </summary>
-    public const string Version = "v2.0.0";
+    public const string Version = "v2.1.0";
 
     /// <summary>
     /// The App name with version.


### PR DESCRIPTION
Updates Tableau.Migration package reference to 6.1.0 and bumps app version to v2.1.0.